### PR TITLE
switched from 1.day.ago to 24.hours.ago to be more precise

### DIFF
--- a/app/models/hot_read.rb
+++ b/app/models/hot_read.rb
@@ -3,6 +3,6 @@ class HotRead < ActiveRecord::Base
   validates :url, presence: true
 
   def self.get_recent
-    where('updated_at >= ?', 1.day.ago).order('count DESC').limit(10)
+    where('updated_at >= ?', 24.hours.ago).order('count DESC').limit(10)
   end
 end


### PR DESCRIPTION
- made active record query more precise